### PR TITLE
I18n for blocked and rate limit pages, add German locale

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,20 @@
+de:
+  devise:
+    failure:
+      account_locked_due_to_high_risk: "Dein Zugriff wurde aufgrund verdächtiger Aktivitäten gesperrt. Bitte kontaktiere unseren Support oder warte auf die automatische Entsperrung."
+
+  beskar:
+    account_locking:
+      high_risk_detected: "Verdächtige Aktivitäten erkannt"
+      locked_for_security: "Zugriff aus Sicherheitsgründen gesperrt"
+      contact_support: "Bitte kontaktiere den Support, um dein Konto zu entsperren"
+    blocked_page:
+      title: "Zugriff verweigert"
+      heading: "Zugriff verweigert"
+      contact_admin: "Wenn du glaubst, dass dies ein Fehler ist, kontaktiere bitte unseren Support."
+      ip_blocked: "Deine IP-Adresse wurde aufgrund verdächtiger Aktivitäten blockiert."
+      access_denied: "Zugriff aufgrund verdächtiger Aktivitäten verweigert."
+    rate_limit_page:
+      title: "Zu viele Anfragen"
+      heading: "Zu viele Anfragen"
+      message: "Du hast das Anfragelimit überschritten. Bitte versuche es später erneut."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,9 +2,19 @@ en:
   devise:
     failure:
       account_locked_due_to_high_risk: "Your account has been locked due to suspicious activity. Please contact support or wait for automatic unlock."
-  
+
   beskar:
     account_locking:
       high_risk_detected: "High risk activity detected on your account"
       locked_for_security: "Account locked for security reasons"
       contact_support: "Please contact support to unlock your account"
+    blocked_page:
+      title: "Access Denied"
+      heading: "Access Denied"
+      contact_admin: "If you believe this is an error, please contact the site administrator."
+      ip_blocked: "Your IP address has been blocked due to suspicious activity."
+      access_denied: "Access denied due to suspicious activity."
+    rate_limit_page:
+      title: "Too Many Requests"
+      heading: "Too Many Requests"
+      message: "You have exceeded the rate limit. Please try again later."

--- a/lib/beskar/middleware/request_analyzer.rb
+++ b/lib/beskar/middleware/request_analyzer.rb
@@ -20,7 +20,7 @@ module Beskar
             Beskar::Logger.warn("🔍 MONITOR-ONLY: Would block request from banned IP: #{ip_address}, but monitor_only=true. Request proceeding normally.", component: :Middleware)
           else
             Beskar::Logger.warn("Blocked request from banned IP: #{ip_address}", component: :Middleware)
-            return blocked_response("Your IP address has been blocked due to suspicious activity.")
+            return blocked_response(I18n.t("beskar.blocked_page.ip_blocked"))
           end
         end
 
@@ -78,7 +78,7 @@ module Beskar
                   "with WAF score #{current_score.round(2)}", component: :Middleware)
                 # Block already handled by WAF.record_violation auto-block logic
                 # But we return 403 immediately
-                return blocked_response("Access denied due to suspicious activity.")
+                return blocked_response(I18n.t("beskar.blocked_page.access_denied"))
               end
             end
           else
@@ -241,7 +241,7 @@ module Beskar
         [
           403,
           {
-            "Content-Type" => "text/html",
+            "Content-Type" => "text/html; charset=utf-8",
             "X-Beskar-Blocked" => "true"
           },
           [render_blocked_page(message)]
@@ -252,7 +252,7 @@ module Beskar
         [
           429,
           {
-            "Content-Type" => "text/html",
+            "Content-Type" => "text/html; charset=utf-8",
             "Retry-After" => "3600",
             "X-Beskar-Rate-Limited" => "true"
           },
@@ -265,7 +265,8 @@ module Beskar
           <!DOCTYPE html>
           <html>
           <head>
-            <title>Access Denied</title>
+            <meta charset="utf-8">
+            <title>#{I18n.t("beskar.blocked_page.title")}</title>
             <style>
               body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
               h1 { color: #d32f2f; }
@@ -273,9 +274,9 @@ module Beskar
             </style>
           </head>
           <body>
-            <h1>Access Denied</h1>
+            <h1>#{I18n.t("beskar.blocked_page.heading")}</h1>
             <p>#{message}</p>
-            <p>If you believe this is an error, please contact the site administrator.</p>
+            <p>#{I18n.t("beskar.blocked_page.contact_admin")}</p>
           </body>
           </html>
         HTML
@@ -286,7 +287,8 @@ module Beskar
           <!DOCTYPE html>
           <html>
           <head>
-            <title>Too Many Requests</title>
+            <meta charset="utf-8">
+            <title>#{I18n.t("beskar.rate_limit_page.title")}</title>
             <style>
               body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
               h1 { color: #ff9800; }
@@ -294,8 +296,8 @@ module Beskar
             </style>
           </head>
           <body>
-            <h1>Too Many Requests</h1>
-            <p>You have exceeded the rate limit. Please try again later.</p>
+            <h1>#{I18n.t("beskar.rate_limit_page.heading")}</h1>
+            <p>#{I18n.t("beskar.rate_limit_page.message")}</p>
           </body>
           </html>
         HTML


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in blocked/rate-limit pages with `I18n.t` calls
- Add `blocked_page` and `rate_limit_page` translations to `en.yml`
- Add German locale file (`de.yml`) with all translations
- Set `Content-Type` charset to UTF-8 and add `<meta charset="utf-8">` to fix encoding issues with non-ASCII characters (e.g. German umlauts)

## Test plan
- [ ] Ban a test IP and verify the 403 page renders with correct translations
- [ ] Trigger rate limiting and verify the 429 page renders correctly
- [ ] Test with German locale to confirm umlauts display properly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive German language support for authentication failures, account security, and access control flows.
  * Internationalized security-related messages across blocked access and rate-limit pages, replacing hardcoded text with localized translations.

* **Bug Fixes**
  * Enhanced security pages with proper UTF-8 character encoding support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->